### PR TITLE
fix: add type to test Change objects

### DIFF
--- a/test/functional/sqs-listener.spec.ts
+++ b/test/functional/sqs-listener.spec.ts
@@ -47,7 +47,7 @@ async function checkFileExists(key: string, bucket: string): Promise<boolean> {
 }
 
 async function waitForConditionOrTimeout(check: Function, limit: number) {
-  return new Promise((resolve) => {
+  return new Promise<void>((resolve) => {
     const startTime = new Date().getTime();
     const interval = setInterval(async () => {
       const timeLapsed = new Date().getTime() - startTime;

--- a/test/unit/change-repsitory.test.ts
+++ b/test/unit/change-repsitory.test.ts
@@ -1,3 +1,4 @@
+import { Change } from "../../src/types/change";
 import { Db, MongoClient } from "mongodb";
 import changeRepository from "../../src/repositories/changes";
 
@@ -25,11 +26,12 @@ describe("changeRepository", () => {
     }).not.toThrow();
   });
 
-  test("should write change to the database", async () => {
+  it("should write change to the database", async () => {
     const repo = changeRepository(db);
-    const change = {
+    const change: Change = {
       articleId: "1234",
       applied: false,
+      type: 'steps',
       user: 'static-for-now',
       path: 'abstract',
       timestamp: 1605198300275,
@@ -59,9 +61,10 @@ describe("changeRepository", () => {
 
   test("should write change to the database", async () => {
     const repo = changeRepository(db);
-    const change = {
+    const change: Change = {
       articleId: "1234",
       applied: false,
+      type: 'steps',
       path: 'abstract',
       user: 'static-for-now',
       timestamp: 1605198300275,

--- a/test/unit/change-repsitory.test.ts
+++ b/test/unit/change-repsitory.test.ts
@@ -59,7 +59,7 @@ describe("changeRepository", () => {
     expect({ ...change, _id: insertedId }).toEqual(changeFromDb);
   });
 
-  test("should write change to the database", async () => {
+  it("should write change to the database", async () => {
     const repo = changeRepository(db);
     const change: Change = {
       articleId: "1234",

--- a/test/unit/change-service.test.ts
+++ b/test/unit/change-service.test.ts
@@ -29,6 +29,7 @@ describe("articleService", () => {
       articleId: "123",
       applied: false,
       user: 'static-for-now',
+      type: 'steps',
       steps: [],
       path: 'abstract',
       timestamp: 1605198300275,

--- a/test/unit/config-utils.test.ts
+++ b/test/unit/config-utils.test.ts
@@ -59,7 +59,7 @@ describe('createConfigFromEnv()', () => {
       AWS_ACCESS_KEY: 'AWS_ACCESS_KEY',
       AWS_SECRET_ACCESS_KEY: 'AWS_SECRET_ACCESS_KEY',
       AWS_BUCKET_INPUT_EVENT_QUEUE_URL: 'AWS_BUCKET_INPUT_EVENT_QUEUE_URL',
-      AWS_END_POINT: 'AWS_END_POINT'
+      AWS_ENDPOINT: 'AWS_ENDPOINT'
     };
     const output = {
       port: 8080,
@@ -70,7 +70,7 @@ describe('createConfigFromEnv()', () => {
       awsAccessKey: 'AWS_ACCESS_KEY',
       awsSecretAccessKey: 'AWS_SECRET_ACCESS_KEY',
       awsBucketInputEventQueueUrl: 'AWS_BUCKET_INPUT_EVENT_QUEUE_URL',
-      awsEndPoint: 'AWS_END_POINT'
+      awsEndPoint: 'AWS_ENDPOINT'
     };
     expect(createConfigFromEnv(input)).toEqual(output);
   });


### PR DESCRIPTION
Not sure how this has sneaked through the pipeline but there are failing tests on master due to a missing `type` property on the `change` object being passed to some unit tests.

Also a config mapping test had a typo in the name.