### PR TITLE
fix: change asset redirect to 302 to prevent cached response

### DIFF
--- a/src/routers/assets.ts
+++ b/src/routers/assets.ts
@@ -35,7 +35,7 @@ export default (assetService: AssetService): express.Router => {
     if (assetUrl === null) {
       res.sendStatus(404);
     } else {
-      res.redirect(301, assetUrl);
+      res.redirect(302, assetUrl);
     }
   });
 

--- a/test/functional/test-asset.spec.ts
+++ b/test/functional/test-asset.spec.ts
@@ -12,33 +12,33 @@ describe('Get /assets', () => {
       .expect(404);
   });
 
-  test('Should return 301 for assets that are found - tiff', async () => {
+  test('Should return 302 for assets that are found - tiff', async () => {
     await agent
       .get('/articles/54296/assets/elife-54296-fig1.tif')
       .set('Accept', 'application/json')
-      .expect(301);
+      .expect(302);
   });
 
-  test('Should return 301 for assets that are found - jpg', async () => {
+  test('Should return 302 for assets that are found - jpg', async () => {
     await agent
       .get('/articles/54296/assets/elife-54296-fig1.jpeg')
       .set('Accept', 'application/json')
-      .expect(301);
+      .expect(302);
   });
 
-  test('Should return 301 for assets that are found - pdf', async () => {
+  test('Should return 302 for assets that are found - pdf', async () => {
     await agent
       .get('/articles/54296/assets/elife-54296.pdf')
       .set('Accept', 'application/json')
-      .expect(301);
+      .expect(302);
   });
 
-  // perphas this shouldn't be possible
-  test('Should return 301 for assets that are found - xml', async () => {
+  // prehaps this shouldn't be possible
+  test('Should return 302 for assets that are found - xml', async () => {
      await agent
       .get('/articles/54296/assets/elife-54296.xml')
       .set('Accept', 'application/json')
-      .expect(301);
+      .expect(302);
   });
 });
 


### PR DESCRIPTION
Can apply some nocache headers if the 302 doesn't solve the signed URL issue. This should do the job though.