### PR TITLE
Add asset uuids to link tiffs to jpegs. 

### DIFF
--- a/src/repositories/articles.ts
+++ b/src/repositories/articles.ts
@@ -14,6 +14,7 @@ export default function articleRepository(db: Db): ArticleRepository {
     insert: async (article: Article) => {
       const { insertedId } = await db.collection("articles").insertOne({
         ...article,
+        created: new Date().toISOString()
       });
       return insertedId as string;
     },

--- a/src/repositories/assets.ts
+++ b/src/repositories/assets.ts
@@ -1,0 +1,26 @@
+import { Db } from "mongodb";
+import { Asset } from "../types/asset";
+
+const MAX_PAGE_SIZE = 100;
+
+export type AssetRepository = {
+  insert: (asset: Asset) => Promise<string>;
+  getByArticleId: (articleId: string, page?: number) => Promise<Array<Asset>>;
+}
+
+export default function assetRepository(db: Db): AssetRepository {
+  return {
+    insert: async (asset: Asset) => {
+      const { insertedId } = await db.collection("assets").insertOne({
+        ...asset,
+        created: new Date().toISOString()
+      });
+      return insertedId as string;
+    },
+    getByArticleId: async (articleId: string, page = 0) => {
+      const skip = page * MAX_PAGE_SIZE;
+      const assets = await db.collection('assets').find({ articleId}).skip(skip).limit(MAX_PAGE_SIZE).toArray();
+      return assets as Array<Asset>;
+    }
+  };
+}

--- a/src/repositories/changes.ts
+++ b/src/repositories/changes.ts
@@ -18,6 +18,7 @@ export default function changeRepository(db: Db): ChangeRepository {
     insert: async (change: Change) => {
       const { insertedId } = await db.collection("changes").insertOne({
         ...change,
+        created: new Date().toISOString()
       });
       return insertedId as string;
     },

--- a/src/routers/assets.ts
+++ b/src/routers/assets.ts
@@ -27,7 +27,13 @@ export default (assetService: AssetService): express.Router => {
 
   router.get("/:fileKey", async (req, res) => {
     const { articleId, fileKey } = req.params; 
-    const assetKey = `${articleId}/${fileKey}`;
+    let assetKey = `${articleId}/${fileKey}`;
+
+    if (!fileKey.includes('/')) {
+      const [ key ] = await assetService.getArticleAssetKeysByFilename(articleId, fileKey);
+      assetKey = key;
+    }
+
     const assetUrl = await assetService.getAssetUrl(assetKey);
     if (assetUrl === null) {
       res.sendStatus(404);

--- a/src/routers/assets.ts
+++ b/src/routers/assets.ts
@@ -2,7 +2,6 @@ import { default as express } from "express";
 import path from 'path';
 import multer from 'multer';
 import { AssetService } from "../services/asset"
-import {v4 as uuidv4} from 'uuid';
 
 const upload = multer();
 
@@ -21,8 +20,7 @@ export default (assetService: AssetService): express.Router => {
       articleId,
       req.file.buffer,
       req.file.mimetype,
-      // TODO: uuid based S3 key should be refactored into asset service
-      uuidv4()+path.extname(req.file.originalname)
+      req.file.originalname
     );
 
     res.json({assetName: s3Name});

--- a/src/routers/assets.ts
+++ b/src/routers/assets.ts
@@ -34,6 +34,11 @@ export default (assetService: AssetService): express.Router => {
       assetKey = key;
     }
 
+    if (!assetKey) {
+      res.sendStatus(404);
+      return;
+    }
+
     const assetUrl = await assetService.getAssetUrl(assetKey);
     if (assetUrl === null) {
       res.sendStatus(404);

--- a/src/routers/assets.ts
+++ b/src/routers/assets.ts
@@ -1,5 +1,4 @@
 import { default as express } from "express";
-import path from 'path';
 import multer from 'multer';
 import { AssetService } from "../services/asset"
 
@@ -27,7 +26,7 @@ export default (assetService: AssetService): express.Router => {
   });
 
   router.get("/:fileKey", async (req, res) => {
-    const { articleId, fileKey } = req.params;
+    const { articleId, fileKey } = req.params; 
     const assetKey = `${articleId}/${fileKey}`;
     const assetUrl = await assetService.getAssetUrl(assetKey);
     if (assetUrl === null) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,6 +21,7 @@ import {
 import { buildDatabaseUri } from './utils/db-utils';
 
 import initialiseDb from "./db";
+import AssetRepository from "./repositories/assets";
 
 // Load the configuration for this service with the following precedence...
 //   process args > environment vars > config file.
@@ -63,11 +64,13 @@ export default async function start() {
     signatureVersion: "v4",
     s3ForcePathStyle: true,
   });
+  // Initialize repositories
+  const assetRepository = AssetRepository(db);
 
   // Initialize services
   const articleService = ArticleService(db);
   const changesService = ChangesService(db);
-  const assetService = AssetService(s3, configManager);
+  const assetService = AssetService(s3, assetRepository, configManager);
 
   // Register middlewares
   app.use(cors());

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,6 +22,9 @@ import { buildDatabaseUri } from './utils/db-utils';
 
 import initialiseDb from "./db";
 import AssetRepository from "./repositories/assets";
+import ChangesRepository from "./repositories/changes";
+import ArticleRepository from "./repositories/articles";
+
 
 // Load the configuration for this service with the following precedence...
 //   process args > environment vars > config file.
@@ -66,10 +69,11 @@ export default async function start() {
   });
   // Initialize repositories
   const assetRepository = AssetRepository(db);
-
+  const changeRepository = ChangesRepository(db)
+  const articleRepository = ArticleRepository(db);
   // Initialize services
-  const articleService = ArticleService(db);
-  const changesService = ChangesService(db);
+  const articleService = ArticleService(articleRepository);
+  const changesService = ChangesService(changeRepository);
   const assetService = AssetService(s3, assetRepository, configManager);
 
   // Register middlewares

--- a/src/services/article.ts
+++ b/src/services/article.ts
@@ -1,15 +1,12 @@
-import { Db } from 'mongodb';
-
 import { Article } from "../types/article";
-import articleRepository from '../repositories/articles';
+import { ArticleRepository } from '../repositories/articles';
 
 export type ArticleService = {
   getArticles: (page: number) => Promise<Array<Article>>;
   findByArticleId: (articleId: string) => Promise<Article>;
 }
 
-export default (db: Db): ArticleService => {
-  const articleRepo = articleRepository(db);
+export default (articleRepo: ArticleRepository): ArticleService => {
   return {
     getArticles: async (page: number) => {
       return articleRepo.get(page);

--- a/src/services/asset.ts
+++ b/src/services/asset.ts
@@ -7,7 +7,7 @@ import { AssetRepository } from "../repositories/assets";
 import { Asset } from "../types/asset";
 
 export type AssetService = {
-  getArticleAssetIdsByFilename: (articleId: string, fileName: string) => Promise<Asset[]>
+  getArticleAssetKeysByFilename: (articleId: string, fileName: string) => Promise<string[]>
   getAsset: (key: string, bucket: string) => Promise<string | Buffer | undefined>;
   getAssetUrl: (key: string) => Promise<string | null>;
   saveAsset: (articleId: string, fileContent: Buffer, mimeType: string, fileName: string) => Promise<string>;
@@ -66,9 +66,9 @@ export default function assetService(s3: S3, assetRepository: AssetRepository, c
         Expires: 3600,
       });
     },
-    getArticleAssetIdsByFilename: async (articleId, fileName) => {
+    getArticleAssetKeysByFilename: async (articleId, fileName) => {
       const { assets } = await assetRepository.getByQuery({articleId, fileName});
-      return assets;
+      return assets.map(asset => `${asset.articleId}/${asset.assetId}/${asset.fileName}`);
     },
     getAsset: async (key: string, bucket: string) => {
       const { Body } = await s3

--- a/src/services/asset.ts
+++ b/src/services/asset.ts
@@ -1,18 +1,21 @@
 import { S3 } from "aws-sdk";
-import { configManager } from "./config-manager";
-import convert from '../utils/convert-image-utils';
 import path from "path";
 import { v4 as uuid } from 'uuid';
+import { configManager } from "./config-manager";
+import convert from '../utils/convert-image-utils';
+import { AssetRepository } from "../repositories/assets";
+
 export type AssetService = {
   getAsset: (key: string, bucket: string) => Promise<string | Buffer | undefined>;
   getAssetUrl: (key: string) => Promise<string | null>;
   saveAsset: (articleId: string, fileContent: Buffer, mimeType: string, fileName: string) => Promise<string>;
 }
 
-export default function assetService(s3: S3, config: typeof configManager): AssetService {
+export default function assetService(s3: S3, assetRepository: AssetRepository, config: typeof configManager): AssetService {
   const targetBucket = config.get("editorS3Bucket");
 
-  const storeFileToTargetS3 = async (Body: Buffer | string = '', Key: string, ContentType: string|undefined) => {
+  const storeFileToTargetS3 = async (Body: Buffer | string = '', articleId: string, assetId: string, fileName: string, ContentType?: string) => {
+    const Key = `${articleId}/${assetId}/${fileName}`;
     const params = {
       Body,
       Bucket: targetBucket,
@@ -21,6 +24,13 @@ export default function assetService(s3: S3, config: typeof configManager): Asse
       ContentType,
     };
     await s3.putObject(params).promise();
+    console.log(
+      `S3 object stored: { Key: ${Key}, Bucket: ${targetBucket} }`
+    );
+    const _id = await assetRepository.insert({ fileName, assetId, articleId})
+    console.log(
+      `Asset stored in Db: { _id: ${_id}, Key: ${Key} }`
+    );
   }
 
   async function checkFileExists(
@@ -65,17 +75,13 @@ export default function assetService(s3: S3, config: typeof configManager): Asse
     },
 
     saveAsset: async (articleId: string, fileContent: Buffer, mimeType: string, fileName: string): Promise<string> => {
-      const ext = fileName?.split('.')?.pop() || mimeType?.split('/')?.pop() || '';
-      const assetKeyPrefix = `${articleId}/${uuid()}`;
-      const assetKey = `${assetKeyPrefix}/${fileName}`;
+      const assetId = uuid();
+
       try {
-        await storeFileToTargetS3(fileContent, assetKey , mimeType);
-        console.log(
-          `Object stored: { Key: ${assetKey}, Bucket: ${targetBucket} }`
-        );
+        await storeFileToTargetS3(fileContent, articleId, assetId, fileName, mimeType);
       } catch (error) {
         throw new Error(
-          `Error when storing object: { Key: ${assetKey}, Bucket: ${targetBucket} } - ${error.message}`
+          `Error when storing S3 object: { Key: ${articleId}/${assetId}/${fileName}, Bucket: ${targetBucket} } - ${error.message}`
         );
       }
 
@@ -87,25 +93,21 @@ export default function assetService(s3: S3, config: typeof configManager): Asse
             fileContent
           );
         } catch(error) {
-          throw new Error(`Error when converting .tif file: { Key: ${assetKey}, Bucket: ${targetBucket} } - ${error.message}`)
+          throw new Error(`Error when converting .tif file: { Key: ${articleId}/${assetId}/${fileName}, Bucket: ${targetBucket} } - ${error.message}`)
         }
-        const { name: keyName } = path.parse(fileName)
-        const jpgAssetKey = path.join(assetKeyPrefix, keyName) + ".jpeg";
 
+        const { name: keyName } = path.parse(fileName)
         try {
           const { buffer: jpgBuffer, contentType: jpgCcontentType } = convertedTif;
-          await storeFileToTargetS3(jpgBuffer, jpgAssetKey, jpgCcontentType?.mime as unknown as string);
-          console.log(
-            `Object stored: { Key: ${jpgAssetKey}, Bucket: ${targetBucket} }`
-          );
+          await storeFileToTargetS3(jpgBuffer, articleId, assetId, keyName + ".jpeg", jpgCcontentType?.mime as unknown as string);
         } catch(error) {
           throw new Error(
-            `Error when storing object: { Key: ${jpgAssetKey}, Bucket: ${targetBucket} } converted from .tif file: { Key: ${assetKey}, Bucket: ${targetBucket} } - ${error.message}`
+            `Error when storing S3 object: { Key: ${path.join(articleId, assetId, keyName) + ".jpeg"}, Bucket: ${targetBucket} } converted from .tif file: { Key: ${articleId}/${assetId}/${fileName}, Bucket: ${targetBucket} } - ${error.message}`
           );
         }
-        return `${keyName}.jpeg`;
+        return `${assetId}/${keyName}.jpeg`;
       }
-      return fileName;
+      return `${assetId}/${fileName}`;
     }
   };
 }

--- a/src/services/asset.ts
+++ b/src/services/asset.ts
@@ -4,8 +4,10 @@ import { v4 as uuid } from 'uuid';
 import { configManager } from "./config-manager";
 import convert from '../utils/convert-image-utils';
 import { AssetRepository } from "../repositories/assets";
+import { Asset } from "../types/asset";
 
 export type AssetService = {
+  getArticleAssetIdsByFilename: (articleId: string, fileName: string) => Promise<Asset[]>
   getAsset: (key: string, bucket: string) => Promise<string | Buffer | undefined>;
   getAssetUrl: (key: string) => Promise<string | null>;
   saveAsset: (articleId: string, fileContent: Buffer, mimeType: string, fileName: string) => Promise<string>;
@@ -63,6 +65,10 @@ export default function assetService(s3: S3, assetRepository: AssetRepository, c
         Key: key,
         Expires: 3600,
       });
+    },
+    getArticleAssetIdsByFilename: async (articleId, fileName) => {
+      const { assets } = await assetRepository.getByQuery({articleId, fileName});
+      return assets;
     },
     getAsset: async (key: string, bucket: string) => {
       const { Body } = await s3

--- a/src/services/changes.ts
+++ b/src/services/changes.ts
@@ -1,5 +1,4 @@
-import { Db } from 'mongodb';
-import changeRepository, {ChangesResultSet} from '../repositories/changes';
+import { ChangeRepository, ChangesResultSet } from '../repositories/changes';
 import { Change } from '../types/change';
 
 export type ChangeService = {
@@ -7,8 +6,7 @@ export type ChangeService = {
   registerChange: (change: Change) => Promise<string>;
 }
 
-export default (db: Db): ChangeService => {
-  const changeRepo = changeRepository(db);
+export default (changeRepo: ChangeRepository): ChangeService => {
   return {
     // todo: do we need an optional filter for version number?
     getChangesforArticle: async (articleId: string, page = 0) => {

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -6,4 +6,5 @@ export type Article = {
   version: string;
   datatype: string;
   fileName: string;
+  created?: string;
 };

--- a/src/types/asset.ts
+++ b/src/types/asset.ts
@@ -1,0 +1,7 @@
+export type Asset = {
+  _id?: string;
+  assetId: string;
+  articleId: string;
+  fileName: string;
+  created?: string;
+};

--- a/src/types/change.ts
+++ b/src/types/change.ts
@@ -30,4 +30,5 @@ export type Change = {
   // todo: this probably needs to be on a step by step basis. Like this because client generate a step for each action.
   applied: boolean; 
   user: string;
+  created?: string;
 } & SerializedChangePayload;

--- a/test/functional/sqs-listener.spec.ts
+++ b/test/functional/sqs-listener.spec.ts
@@ -78,10 +78,10 @@ describe("SQS bucket listener", () => {
     const pdfExists = async () =>
       checkFileExists(`${folderName}/elife-00006.pdf`, editorBucket);
 
-    expect(xmlExists()).resolves.toBe(false);
-    expect(jpgExists()).resolves.toBe(false);
-    expect(tiffExists()).resolves.toBe(false);
-    expect(pdfExists()).resolves.toBe(false);
+    await expect(xmlExists()).resolves.toBe(false);
+    await expect(jpgExists()).resolves.toBe(false);
+    await expect(tiffExists()).resolves.toBe(false);
+    await expect(pdfExists()).resolves.toBe(false);
 
     const zipBuffer = fs.readFileSync(
       path.join(__dirname, "..", "test-files", "elife-00006-vor-r1.zip")
@@ -98,9 +98,9 @@ describe("SQS bucket listener", () => {
 
     await waitForConditionOrTimeout(xmlExists, 50000);
 
-    expect(xmlExists()).resolves.toBe(true);
-    expect(jpgExists()).resolves.toBe(true);
-    expect(tiffExists()).resolves.toBe(true);
-    expect(pdfExists()).resolves.toBe(true);
+    await expect(xmlExists()).resolves.toBe(true);
+    await expect(jpgExists()).resolves.toBe(true);
+    await expect(tiffExists()).resolves.toBe(true);
+    await expect(pdfExists()).resolves.toBe(true);
   });
 });

--- a/test/functional/test-asset.spec.ts
+++ b/test/functional/test-asset.spec.ts
@@ -4,6 +4,23 @@ import * as request from 'supertest';
 const API_URL = 'localhost:8080';
 const agent = request.agent(API_URL);
 
+describe('Post /assets', () => {
+  it('Should return 200 and asset key if file is uploaded', async () => {
+    const buffer = Buffer.from('some file data');
+    const resp = await agent
+      .post("/articles/54296/assets")
+      .set('content-type', 'multipart/form-data')
+      .attach('file', buffer, 'custom_file_name.txt')
+      .expect(200);
+    expect(JSON.parse(resp.text).assetName).toHaveLength(40)
+  });
+  it('Should return 400 if no file is uploaded', async () => {
+    await agent
+    .post("/articles/54296/assets")
+    .expect(400);
+  });
+});
+
 describe('Get /assets', () => {
   test('Returns 404 for assets that are not found', async () => {
     await agent
@@ -39,22 +56,5 @@ describe('Get /assets', () => {
       .get('/articles/54296/assets/elife-54296.xml')
       .set('Accept', 'application/json')
       .expect(302);
-  });
-});
-
-describe('Post /assets', () => {
-  it('Should return 200 and asset key if file is uploaded', async () => {
-    const buffer = Buffer.from('some file data');
-    const resp = await agent
-      .post("/articles/54296/assets")
-      .set('content-type', 'multipart/form-data')
-      .attach('file', buffer, 'custom_file_name.txt')
-      .expect(200);
-    expect(JSON.parse(resp.text).assetName).toHaveLength(40)
-  });
-  it('Should return 400 if no file is uploaded', async () => {
-    await agent
-    .post("/articles/54296/assets")
-    .expect(400);
   });
 });

--- a/test/functional/test-asset.spec.ts
+++ b/test/functional/test-asset.spec.ts
@@ -12,7 +12,7 @@ describe('Post /assets', () => {
       .set('content-type', 'multipart/form-data')
       .attach('file', buffer, 'custom_file_name.txt')
       .expect(200);
-    expect(JSON.parse(resp.text).assetName).toHaveLength(40)
+    expect(JSON.parse(resp.text).assetName).toHaveLength(57)
   });
   it('Should return 400 if no file is uploaded', async () => {
     await agent

--- a/test/functional/test-changes.spec.ts
+++ b/test/functional/test-changes.spec.ts
@@ -47,7 +47,7 @@ describe("Get /article/id/changes", () => {
           .expect("Content-Type", /json/)
           .then((response) => {
             const changes = response.body.changes;
-            const { _id, ...rest } = changes[0];
+            const { _id, created, ...rest } = changes[0];
             expect(changes.length).toBe(1);
             expect(rest).toEqual({
               ...change,

--- a/test/unit/article-repository.test.ts
+++ b/test/unit/article-repository.test.ts
@@ -15,12 +15,12 @@ describe("articleRepository", () => {
   let db: Db;
 
   beforeAll(async () => {
-    connection = await MongoClient.connect(process.env.MONGO_URL || "", { useUnifiedTopology: true });
+    connection = await MongoClient.connect(process.env.MONGO_URL || "", { useUnifiedTopology: true, useNewUrlParser: true });
     db = await connection.db();
   });
 
   beforeEach(async () => {
-    await db.dropDatabase();
+    await db.collection('articles').deleteMany({});
   })
 
   afterAll(async () => {

--- a/test/unit/article-service.test.ts
+++ b/test/unit/article-service.test.ts
@@ -1,13 +1,14 @@
 import { Db } from "mongodb";
+import { ArticleRepository } from "../../src/repositories/articles";
 import articleService from "../../src/services/article";
 
 let getByArticleIdMock = jest.fn().mockReturnValue(null);
 let getArticlesMock = jest.fn().mockReturnValue(null);
-jest.mock('../../src/repositories/articles', () => {
-  return jest.fn().mockImplementation(() => ({
-    getByArticleId: getByArticleIdMock,
-    get: getArticlesMock
-}))});
+const mockArticleRepo = {
+  insert: jest.fn(),
+  getByArticleId: getByArticleIdMock,
+  get: getArticlesMock
+} as ArticleRepository;
 
 describe("articleService", () => {
   const db = {} as unknown as Db;
@@ -18,13 +19,13 @@ describe("articleService", () => {
 
   test("should not throw", () => {
     expect(() => {
-      articleService({} as unknown as Db);
+      articleService(mockArticleRepo);
     }).not.toThrow();
   });
 
   test("Returns null if article is not found", async () => {
     getByArticleIdMock = jest.fn().mockReturnValue(null);
-    const result = await articleService(db).findByArticleId("123");
+    const result = await articleService(mockArticleRepo).findByArticleId("123");
     expect(result).toBe(null);
   });
 
@@ -38,14 +39,14 @@ describe("articleService", () => {
       version: "v1"
     };
     getByArticleIdMock = jest.fn().mockReturnValue(data);
-    const result = await articleService(db).findByArticleId("12345");
+    const result = await articleService(mockArticleRepo).findByArticleId("12345");
     expect(result).toBeDefined();
     expect(result).toEqual({...data });
   });
 
   test("Returns empty array if no articles", async () => {
     getArticlesMock = jest.fn().mockReturnValue([]);
-    const articles = await articleService(db).getArticles(0);
+    const articles = await articleService(mockArticleRepo).getArticles(0);
     expect(articles.length).toBe(0);
     expect(getArticlesMock).toBeCalledWith(0);
   });
@@ -58,7 +59,7 @@ describe("articleService", () => {
       fileName: "main.xml",
     };
     getArticlesMock = jest.fn().mockReturnValue([data]);
-    const articles = await articleService(db).getArticles(0);
+    const articles = await articleService(mockArticleRepo).getArticles(0);
     expect(articles.length).toBe(1);
     expect(articles[0]).toEqual({ ...data });
     expect(getArticlesMock).toBeCalledWith(0);

--- a/test/unit/article-service.test.ts
+++ b/test/unit/article-service.test.ts
@@ -2,8 +2,9 @@ import { Db } from "mongodb";
 import { ArticleRepository } from "../../src/repositories/articles";
 import articleService from "../../src/services/article";
 
-let getByArticleIdMock = jest.fn().mockReturnValue(null);
-let getArticlesMock = jest.fn().mockReturnValue(null);
+let getByArticleIdMock = jest.fn();
+let getArticlesMock = jest.fn();
+
 const mockArticleRepo = {
   insert: jest.fn(),
   getByArticleId: getByArticleIdMock,
@@ -15,6 +16,8 @@ describe("articleService", () => {
 
   beforeEach(async () => {
     jest.restoreAllMocks();
+    getByArticleIdMock.mockImplementation(() => null);
+    getArticlesMock.mockImplementation(() => null);
   });
 
   test("should not throw", () => {
@@ -24,7 +27,6 @@ describe("articleService", () => {
   });
 
   test("Returns null if article is not found", async () => {
-    getByArticleIdMock = jest.fn().mockReturnValue(null);
     const result = await articleService(mockArticleRepo).findByArticleId("123");
     expect(result).toBe(null);
   });
@@ -38,27 +40,27 @@ describe("articleService", () => {
       fileName: "main.xml",
       version: "v1"
     };
-    getByArticleIdMock = jest.fn().mockReturnValue(data);
+    getByArticleIdMock.mockImplementation(() => data);
     const result = await articleService(mockArticleRepo).findByArticleId("12345");
     expect(result).toBeDefined();
     expect(result).toEqual({...data });
   });
 
   test("Returns empty array if no articles", async () => {
-    getArticlesMock = jest.fn().mockReturnValue([]);
+    getArticlesMock.mockImplementation(() => []);
     const articles = await articleService(mockArticleRepo).getArticles(0);
     expect(articles.length).toBe(0);
     expect(getArticlesMock).toBeCalledWith(0);
   });
 
-  test("Returns  array if there articles", async () => {
+  test("Returns  array if there are articles", async () => {
     const data = {
       xml: "<xml></xml",
       datatype: "xml",
       articleId: "12345",
       fileName: "main.xml",
     };
-    getArticlesMock = jest.fn().mockReturnValue([data]);
+    getArticlesMock.mockImplementation(() => [data]);
     const articles = await articleService(mockArticleRepo).getArticles(0);
     expect(articles.length).toBe(1);
     expect(articles[0]).toEqual({ ...data });

--- a/test/unit/asset-repository.test.ts
+++ b/test/unit/asset-repository.test.ts
@@ -1,0 +1,119 @@
+import { Asset } from "../../src/types/asset";
+import { Db, MongoClient } from "mongodb";
+import assetRepository from "../../src/repositories/assets";
+
+const largeAssetCollection = Array(101).fill({
+  assetId: '10000',
+  articleId: 'articleId',
+  fileName: "someotherfile.tiff",
+  created: new Date().toISOString()
+}).map((article, index) => ({...article, assetId: (Number(article.assetId) + index).toString() }));
+
+
+describe("assetRepository", () => {
+  let connection: MongoClient;
+  let db: Db;
+
+  beforeAll(async () => {
+    connection = await MongoClient.connect(process.env.MONGO_URL || "", {
+      useUnifiedTopology: true,
+    });
+    db = await connection.db();
+  });
+
+  beforeEach(async () => {
+    await db.dropDatabase();
+  });
+
+  afterAll(async () => {
+    await connection.close();
+  });
+  test("should not throw", () => {
+    expect(() => {
+      assetRepository(db);
+    }).not.toThrow();
+  });
+  describe('insert', () => {
+    test("insert should return id", async () => {
+      const data: Asset = {
+        assetId: 'assetid',
+        articleId: "articleid",
+        fileName: "main.tiff",
+      };
+      const insertedId = await assetRepository(db).insert(data);
+      expect(insertedId).toBeDefined();
+    });
+    test("entry should exist in db after insert", async () => {
+      const data: Asset = {
+        assetId: 'assetid',
+        articleId: "articleid",
+        fileName: "main.tiff",
+      };
+      const insertedId = await assetRepository(db).insert(data);
+      expect(insertedId).toBeDefined();
+      await expect(db.collection("assets").findOne({ _id: insertedId })).resolves.toEqual(expect.objectContaining(data));
+    });
+    test("entry should have a created value", async () => {
+      const data: Asset = {
+        assetId: 'assetid',
+        articleId: "articleid",
+        fileName: "main.tiff",
+      };
+      await assetRepository(db).insert(data);
+      const asset = await db.collection("assets").findOne({ articleId: "articleid" });
+      expect(asset.created).toBeDefined();
+    });
+  });
+  describe("getByArticleId", () => {
+    test("returns assets with given ArticleId", async () => {
+      await db.collection("assets").insertMany([
+        {
+          assetId: 'assetid1',
+          articleId: 'articleId1',
+          fileName: "somefile.tiff",
+          created: new Date().toISOString()
+        },
+        {
+          assetId: 'assetid2',
+          articleId: 'articleId1',
+          fileName: "someotherfile.tiff",
+          created: new Date().toISOString()
+        },
+        {
+          assetId: 'assetid3',
+          articleId: 'articleId2',
+          fileName: "somefile.tiff",
+          created: new Date().toISOString()
+        },
+        {
+          assetId: 'assetid4',
+          articleId: 'articleId2',
+          fileName: "someotherfile.tiff",
+          created: new Date().toISOString()
+        }
+    ]);
+      const assetCollection1 = await assetRepository(db).getByArticleId('articleId1');
+      expect(assetCollection1).toHaveLength(2);
+      const assetCollection2 = await assetRepository(db).getByArticleId('articleId2');
+      expect(assetCollection2).toHaveLength(2);
+      assetCollection1.forEach(asset => {
+        expect(asset.articleId).toBe('articleId1');
+      });
+      assetCollection2.forEach(asset => {
+        expect(asset.articleId).toBe('articleId2');
+      });
+    });
+    test('it defaults to first 100 assets', async () => {
+      await db.collection("assets").insertMany(largeAssetCollection);
+      const returnedArticles = await assetRepository(db).getByArticleId('articleId');
+      expect(returnedArticles.length).toBe(100);
+      expect(returnedArticles[0].assetId).toBe("10000");
+    });
+    test("gets assets from given page of results", async () => {
+      await db.collection("assets").insertMany(largeAssetCollection);
+      const returnedArticles = await assetRepository(db).getByArticleId('articleId', 1);
+      expect(returnedArticles.length).toBe(1);
+      expect(returnedArticles[0].assetId).toBe("10100");
+    })
+  });
+});

--- a/test/unit/asset-repository.test.ts
+++ b/test/unit/asset-repository.test.ts
@@ -17,13 +17,14 @@ describe("assetRepository", () => {
 
   beforeAll(async () => {
     connection = await MongoClient.connect(process.env.MONGO_URL || "", {
+      useNewUrlParser: true,
       useUnifiedTopology: true,
     });
     db = await connection.db();
   });
 
   beforeEach(async () => {
-    await db.dropDatabase();
+    await db.collection('assets').deleteMany({});
   });
 
   afterAll(async () => {

--- a/test/unit/asset-service.test.ts
+++ b/test/unit/asset-service.test.ts
@@ -3,6 +3,8 @@ import assetService from "../../src/services/asset";
 import { ConfigManagerInstance } from "../../src/services/config-manager";
 import imageConverter from '../../src/utils/convert-image-utils';
 
+jest.mock('uuid', () => ({ v4: () => '11111111-1111-1111-1111-111111111111'}));
+
 const getSignedUrlMock = jest.fn();
 const headObjectMock = jest.fn();
 const putObjectMock = jest.fn();
@@ -39,8 +41,8 @@ describe("assetService", () => {
       const asset = await assetService(
         mockS3,
         mockConfigManager
-      ).getAsset("12304/asset/name.jpg", "someBucket");
-      expect(getObjectMock).toBeCalledWith({ Key: "12304/asset/name.jpg", Bucket: "someBucket" });
+      ).getAsset("12304/11111111-1111-1111-1111-111111111111/name.jpg", "someBucket");
+      expect(getObjectMock).toBeCalledWith({ Key: "12304/11111111-1111-1111-1111-111111111111/name.jpg", Bucket: "someBucket" });
       expect(asset).toBe('object');
     });
 
@@ -49,7 +51,7 @@ describe("assetService", () => {
       await expect(assetService(
         mockS3,
         mockConfigManager
-      ).getAsset("12304/asset/name.jpg", "someBucket")).rejects.toThrow('Some Error')
+      ).getAsset("12304/11111111-1111-1111-1111-111111111111/name.jpg", "someBucket")).rejects.toThrow('Some Error')
     });
   });
 
@@ -58,11 +60,11 @@ describe("assetService", () => {
         const url = await assetService(
           mockS3,
           mockConfigManager
-        ).getAssetUrl("12304/asset/name.jpg");
+        ).getAssetUrl("12304/11111111-1111-1111-1111-111111111111/name.jpg");
         expect(url).toBe("http://mock");
         expect(getSignedUrlMock).toHaveBeenCalledWith("getObject", {
           Bucket: "editorS3Bucket",
-          Key: "12304/asset/name.jpg",
+          Key: "12304/11111111-1111-1111-1111-111111111111/name.jpg",
           Expires: 3600,
         });
       });
@@ -83,7 +85,7 @@ describe("assetService", () => {
         await expect(assetService(
           mockS3,
           mockConfigManager
-        ).getAssetUrl("12304/asset/name.jpg")).rejects.toThrow("SomeError");
+        ).getAssetUrl("12304/11111111-1111-1111-1111-111111111111/name.jpg")).rejects.toThrow("SomeError");
       });
     });
     describe("saveAsset", () => {
@@ -95,7 +97,7 @@ describe("assetService", () => {
         expect(assetkey).toBe("someFileName.jpeg");
         expect(putObjectMock).toBeCalledWith(expect.objectContaining({
           Bucket: "editorS3Bucket",
-          Key: "11111/someFileName.jpeg",
+          Key: "11111/11111111-1111-1111-1111-111111111111/someFileName.jpeg",
           ACL: "private",
           ContentType: "image/jpeg",
         }));
@@ -105,7 +107,7 @@ describe("assetService", () => {
         await expect(assetService(
           mockS3,
           mockConfigManager
-        ).saveAsset("11111", Buffer.from("some content"), "image/jpeg", "someFileName.jpeg")).rejects.toThrow("Error when storing object: { Key: 11111/someFileName.jpeg, Bucket: editorS3Bucket } - Some Error");
+        ).saveAsset("11111", Buffer.from("some content"), "image/jpeg", "someFileName.jpeg")).rejects.toThrow("Error when storing object: { Key: 11111/11111111-1111-1111-1111-111111111111/someFileName.jpeg, Bucket: editorS3Bucket } - Some Error");
       });
     
       it("converts a tiff to a jpeg and stores both and returns jpeg key", async () => {
@@ -117,13 +119,13 @@ describe("assetService", () => {
         expect(putObjectMock).toBeCalledTimes(2);
         expect(putObjectMock).toBeCalledWith(expect.objectContaining({
           Bucket: "editorS3Bucket",
-          Key: "11111/someFileName.tiff",
+          Key: "11111/11111111-1111-1111-1111-111111111111/someFileName.tiff",
           ACL: "private",
           ContentType: "image/tiff",
         }));
         expect(putObjectMock).toBeCalledWith(expect.objectContaining({
           Bucket: "editorS3Bucket",
-          Key: "11111/someFileName.jpeg",
+          Key: "11111/11111111-1111-1111-1111-111111111111/someFileName.jpeg",
           ACL: "private",
           ContentType: "image/jpeg",
         }));
@@ -134,7 +136,7 @@ describe("assetService", () => {
         await expect(assetService(
           mockS3,
           mockConfigManager
-        ).saveAsset("11111", Buffer.from("some content"), "image/tiff", "someFileName.tiff")).rejects.toThrow("Error when converting .tif file: { Key: 11111/someFileName.tiff, Bucket: editorS3Bucket } - Error converting");
+        ).saveAsset("11111", Buffer.from("some content"), "image/tiff", "someFileName.tiff")).rejects.toThrow("Error when converting .tif file: { Key: 11111/11111111-1111-1111-1111-111111111111/someFileName.tiff, Bucket: editorS3Bucket } - Error converting");
       });
 
       it("converts both .tif and .tiff files", async () => {
@@ -153,14 +155,14 @@ describe("assetService", () => {
 
       it("throws correct error if storing the converted tif file fails", async () => {
         const mockPutObject = jest.fn((params) => { 
-          if(params.Key === "11111/someFileName.jpeg") { throw new Error("Some Error")}
+          if(params.Key === "11111/11111111-1111-1111-1111-111111111111/someFileName.jpeg") { throw new Error("Some Error")}
           return { promise: () => {} };
         });
         putObjectMock.mockImplementation(mockPutObject as unknown as () => { promise: () => void });
         await expect(assetService(
           mockS3,
           mockConfigManager
-        ).saveAsset("11111", Buffer.from("some content"), "image/tiff", "someFileName.tif")).rejects.toThrow("Error when storing object: { Key: 11111/someFileName.jpeg, Bucket: editorS3Bucket } converted from .tif file: { Key: 11111/someFileName.tif, Bucket: editorS3Bucket } - Some Error");
+        ).saveAsset("11111", Buffer.from("some content"), "image/tiff", "someFileName.tif")).rejects.toThrow("Error when storing object: { Key: 11111/11111111-1111-1111-1111-111111111111/someFileName.jpeg, Bucket: editorS3Bucket } converted from .tif file: { Key: 11111/11111111-1111-1111-1111-111111111111/someFileName.tif, Bucket: editorS3Bucket } - Some Error");
       });
     });
   });

--- a/test/unit/change-repsitory.test.ts
+++ b/test/unit/change-repsitory.test.ts
@@ -55,8 +55,9 @@ describe("changeRepository", () => {
     const changeFromDb = await db
       .collection("changes")
       .findOne({ articleId: change.articleId });
+    delete changeFromDb.created;
     expect(insertedId).toBeDefined();
-    expect({ ...change, _id: insertedId }).toEqual(changeFromDb);
+    expect(changeFromDb).toMatchObject({ ...change, _id: insertedId });
   });
 
   it("should write change to the database", async () => {
@@ -87,6 +88,7 @@ describe("changeRepository", () => {
     const insertedId = await repo.insert(change);
     expect(insertedId).toBeDefined();
     const changes = await repo.get("1234");
-    expect({ total: 1, changes: [{ ...change, _id: insertedId }] }).toEqual(changes);
+    changes.changes.forEach(element => delete element.created)
+    expect(changes).toStrictEqual(expect.objectContaining({ total: 1, changes: [{ ...change, _id: insertedId }] }));
   });
 });

--- a/test/unit/change-repsitory.test.ts
+++ b/test/unit/change-repsitory.test.ts
@@ -52,11 +52,11 @@ describe("changeRepository", () => {
       ],
     };
     const insertedId = await repo.insert(change);
+    expect(insertedId).toBeDefined();
     const changeFromDb = await db
       .collection("changes")
       .findOne({ articleId: change.articleId });
     delete changeFromDb.created;
-    expect(insertedId).toBeDefined();
     expect(changeFromDb).toMatchObject({ ...change, _id: insertedId });
   });
 

--- a/test/unit/change-repsitory.test.ts
+++ b/test/unit/change-repsitory.test.ts
@@ -8,13 +8,14 @@ describe("changeRepository", () => {
 
   beforeAll(async () => {
     connection = await MongoClient.connect(process.env.MONGO_URL || "", {
+      useNewUrlParser: true,
       useUnifiedTopology: true,
     });
     db = await connection.db();
   });
 
   beforeEach(async () => {
-    await db.dropDatabase();
+    await db.collection('changes').deleteMany({});
   });
 
   afterAll(async () => {

--- a/test/unit/change-service.test.ts
+++ b/test/unit/change-service.test.ts
@@ -1,7 +1,7 @@
 import changeService from "../../src/services/changes";
 
-let insertMock = jest.fn().mockReturnValue(null);
-let getMock = jest.fn().mockReturnValue(null);
+let insertMock = jest.fn();
+let getMock = jest.fn();
 const mockChangesRepo =  {
     insert: insertMock,
     get: getMock,
@@ -11,6 +11,8 @@ describe("changeService", () => {
 
   beforeEach(async () => {
     jest.restoreAllMocks();
+    getMock.mockImplementation(() => null);
+    insertMock.mockImplementation(() => null);
   });
 
   test("should not throw", () => {
@@ -20,7 +22,7 @@ describe("changeService", () => {
   });
 
   test("Returns id if inserted", async () => {
-    insertMock = jest.fn().mockReturnValue("507f1f77bcf86cd799439011");
+    insertMock.mockImplementation(() => "507f1f77bcf86cd799439011");
     const insertedId = await changeService(mockChangesRepo).registerChange({
       articleId: "123",
       applied: false,
@@ -56,7 +58,7 @@ describe("changeService", () => {
         },
       ],
     };
-    getMock = jest.fn().mockReturnValue({ total: 1, changes: [change] });
+    getMock.mockImplementation(() => ({ total: 1, changes: [change] }));
     const changes = await changeService(mockChangesRepo).getChangesforArticle("1234", 0);
     expect(changes).toEqual({ total: 1, changes: [change] });
   });

--- a/test/unit/change-service.test.ts
+++ b/test/unit/change-service.test.ts
@@ -7,7 +7,7 @@ const mockChangesRepo =  {
     get: getMock,
 };
 
-describe("articleService", () => {
+describe("changeService", () => {
 
   beforeEach(async () => {
     jest.restoreAllMocks();

--- a/test/unit/change-service.test.ts
+++ b/test/unit/change-service.test.ts
@@ -1,17 +1,13 @@
-import { Db } from "mongodb";
 import changeService from "../../src/services/changes";
 
 let insertMock = jest.fn().mockReturnValue(null);
 let getMock = jest.fn().mockReturnValue(null);
-jest.mock("../../src/repositories/changes", () => {
-  return jest.fn().mockImplementation(() => ({
+const mockChangesRepo =  {
     insert: insertMock,
     get: getMock,
-  }));
-});
+};
 
 describe("articleService", () => {
-  const db = ({} as unknown) as Db;
 
   beforeEach(async () => {
     jest.restoreAllMocks();
@@ -19,13 +15,13 @@ describe("articleService", () => {
 
   test("should not throw", () => {
     expect(() => {
-      changeService(({} as unknown) as Db);
+      changeService((mockChangesRepo));
     }).not.toThrow();
   });
 
   test("Returns id if inserted", async () => {
     insertMock = jest.fn().mockReturnValue("507f1f77bcf86cd799439011");
-    const insertedId = await changeService(db).registerChange({
+    const insertedId = await changeService(mockChangesRepo).registerChange({
       articleId: "123",
       applied: false,
       user: 'static-for-now',
@@ -61,7 +57,7 @@ describe("articleService", () => {
       ],
     };
     getMock = jest.fn().mockReturnValue({ total: 1, changes: [change] });
-    const changes = await changeService(db).getChangesforArticle("1234", 0);
+    const changes = await changeService(mockChangesRepo).getChangesforArticle("1234", 0);
     expect(changes).toEqual({ total: 1, changes: [change] });
   });
 });

--- a/test/unit/import-handler.test.ts
+++ b/test/unit/import-handler.test.ts
@@ -11,6 +11,7 @@ const dbMock = {
 const getAssetMock = jest.fn();
 const saveAssetMock = jest.fn();
 const assetServiceMock = {
+  getArticleAssetKeysByFilename: jest.fn(),
   getAsset: getAssetMock,
   getAssetUrl: jest.fn(),
   saveAsset: saveAssetMock


### PR DESCRIPTION
All assets should be stored `${articleId}/${assetId}/${fileName}`, GET endpoint should detect when no assetId is passed (the client is not aware of the uuid because it's pulled from raw xml) and do a lookup to find file.