### PR TITLE
feat: add getArticleManuscript function

### DIFF
--- a/src/model/affiliation.ts
+++ b/src/model/affiliation.ts
@@ -29,3 +29,7 @@ export class Affiliation extends BackmatterEntity {
     this.address = json.address as { city: string };
   }
 }
+
+export function createAffiliationsState(affiliationsXml: Element[]): Affiliation[] {
+  return affiliationsXml.map((xml) => new Affiliation(xml));
+}

--- a/src/model/manuscript.ts
+++ b/src/model/manuscript.ts
@@ -1,6 +1,6 @@
 import {EditorState} from 'prosemirror-state';
+import { Affiliation } from './affiliation';
 // import { Person } from 'app/models/person';
-// import { Affiliation } from 'app/models/affiliation';
 // import { Reference } from 'app/models/reference';
 import {RelatedArticle} from './related-article';
 // import { ArticleInformation } from 'app/models/article-information';
@@ -16,7 +16,7 @@ export type Manuscript = {
   title: EditorState;
   // articleInfo: ArticleInformation;
   // authors: Person[];
-  // affiliations: Affiliation[];
+  affiliations: Affiliation[];
   abstract: EditorState;
   impactStatement: EditorState;
   body: EditorState;

--- a/src/xml-exporter/article-parser.ts
+++ b/src/xml-exporter/article-parser.ts
@@ -7,6 +7,7 @@ import {Article} from "../types/article";
 
 import { parseXML } from "./xml-utils";
 import {createRelatedArticleState} from "../model/related-article";
+import { createAffiliationsState } from "../model/affiliation";
 
 export function getArticleManuscript(article: Article): Manuscript {
   const xmlDoc = parseXML(article.xml);
@@ -20,9 +21,10 @@ export function getArticleManuscript(article: Article): Manuscript {
     .find((el: Element) => el.getAttribute('abstract-type') === 'toc');
 
   // // const authors = doc.querySelectorAll('contrib[contrib-type="author"]');
-  // // const affiliations = doc.querySelectorAll('contrib-group:first-of-type aff');
   // // const references = doc.querySelectorAll('ref-list ref element-citation');
   // // const authorNotes = doc.querySelector('author-notes');
+
+  const affiliations = xmlDoc.querySelectorAll('contrib-group:first-of-type aff');
   const relatedArticles = xmlDoc.querySelectorAll('related-article');
   const acknowledgements: Element | null = xmlDoc.querySelector('ack');
   const body = xmlDoc.querySelector('body') as Element;
@@ -36,7 +38,7 @@ export function getArticleManuscript(article: Article): Manuscript {
 
     // keywordGroups: createKeywordGroupsState(Array.from(keywordGroups)),
     // authors: authorsState,
-    // affiliations: createAffiliationsState(Array.from(affiliations)),
+    affiliations: createAffiliationsState(Array.from(affiliations)),
     // references: createReferencesState(Array.from(references)),
     relatedArticles: createRelatedArticleState(Array.from(relatedArticles)),
     // articleInfo: new ArticleInformation(doc.documentElement, authorsState),

--- a/test/unit/model/affiliation.test.ts
+++ b/test/unit/model/affiliation.test.ts
@@ -103,7 +103,8 @@ describe('createAffiliationsState', () => {
     expect(affiliations).toHaveLength(2);
     expect(affiliations[0]).toBeInstanceOf(Affiliation);
     expect(affiliations[1]).toBeInstanceOf(Affiliation);
-    expect(affiliations[0]).toStrictEqual(expect.objectContaining({
+    expect(affiliations).toContainEqual(expect.objectContaining({
+      _id: 'aff1',
       label: 'label',
       institution: {
         name: 'Tech Department, eLife Sciences'
@@ -113,8 +114,9 @@ describe('createAffiliationsState', () => {
       },
       country: 'United Kingdom'
     }));
-    expect(affiliations[1]).toStrictEqual(expect.objectContaining({
-      label: '1',
+    expect(affiliations).toContainEqual(expect.objectContaining({
+      _id: 'aff2',
+      label: '2',
       institution: {
         name: 'Department, University'
       },

--- a/test/unit/model/affiliation.test.ts
+++ b/test/unit/model/affiliation.test.ts
@@ -1,4 +1,7 @@
-import { Affiliation } from '../../../src/model/affiliation';
+/**
+ * @jest-environment jsdom
+ */
+import { Affiliation, createAffiliationsState } from '../../../src/model/affiliation';
 
 describe('Affiliation', () => {
   it('returns empty Affiliation when called with no data', () => {
@@ -36,4 +39,52 @@ describe('Affiliation', () => {
       expect(affiliation).toStrictEqual(expect.objectContaining(mockData));
     });
   });
+});
+
+describe('createAffiliationsState', () => {
+  it('returns empty array when passed an empty array', () => {
+    expect(createAffiliationsState([])).toStrictEqual([]);
+  });
+  it('returns an Affiliation instance for each affiliation xml element', () => {
+    const xmlWrapper = document.createElement('div');
+    xmlWrapper.innerHTML = `<aff id="aff1">
+        <label>label</label>
+        <institution content-type="dept">Tech Department</institution>
+        <institution>eLife Sciences</institution>
+        <addr-line><named-content content-type="city">Cambridge</named-content></addr-line>
+        <country>United Kingdom</country>
+      </aff>
+      <aff id="aff2">
+        <label>2</label>
+        <institution content-type="dept">Department</institution>
+        <institution>University</institution>
+        <addr-line><named-content content-type="city">City</named-content></addr-line>
+        <country>Country</country>
+      </aff>`;
+
+    const affiliations = createAffiliationsState(Array.from(xmlWrapper.querySelectorAll('aff')));
+    expect(affiliations).toHaveLength(2);
+    expect(affiliations[0]).toBeInstanceOf(Affiliation);
+    expect(affiliations[1]).toBeInstanceOf(Affiliation);
+    expect(affiliations[0]).toStrictEqual(expect.objectContaining({
+      label: 'label',
+      institution: {
+        name: 'Tech Department, eLife Sciences'
+      },
+      address: {
+        city: 'Cambridge'
+      },
+      country: 'United Kingdom'
+    }));
+    expect(affiliations[1]).toStrictEqual(expect.objectContaining({
+      label: '1',
+      institution: {
+        name: 'Department, University'
+      },
+      address: {
+        city: 'City'
+      },
+      country: 'Country'
+    }));
+  })
 });

--- a/test/unit/model/changes-utils.test.ts
+++ b/test/unit/model/changes-utils.test.ts
@@ -142,7 +142,8 @@ const mockManuscript: Manuscript = {
   impactStatement: EditorState.create({ schema: textSchema}),
   body: EditorState.create({ schema: textSchema}),
   acknowledgements: EditorState.create({ schema: textSchema}),
-  relatedArticles: []
+  relatedArticles: [],
+  affiliations: []
 };
 
 describe('manuscriptEntityToJson', () => {


### PR DESCRIPTION
This should pass CI once https://github.com/libero/editor-article-store/pull/70 goes in as the tests rely on `fromXML` working.