### PR TITLE
refactor: create toXml function on non-prosemirror classes

### DIFF
--- a/src/model/affiliation.ts
+++ b/src/model/affiliation.ts
@@ -62,12 +62,9 @@ export class Affiliation extends BackmatterEntity {
     department.appendChild(xmlDoc.createTextNode(get(this, 'institution.name', '')));
     affEl.appendChild(department);
   
-    const addressLine = xmlDoc.createElement('addr-line');
-    const city = xmlDoc.createElement('named-content');
-    city.setAttribute('content-type', 'city');
+    const city = xmlDoc.createElement('city');
     city.appendChild(xmlDoc.createTextNode(this.address?.city || ''));
-    addressLine.appendChild(city);
-    affEl.appendChild(addressLine);
+    affEl.appendChild(city);
   
     const country = xmlDoc.createElement('country');
     country.appendChild(xmlDoc.createTextNode(this.country || ''));

--- a/src/model/person.ts
+++ b/src/model/person.ts
@@ -67,7 +67,7 @@ export class Person extends BackmatterEntity {
       const orcidEl = xmlDoc.createElement('contrib-id');
       orcidEl.setAttribute('contrib-id-type', 'orcid');
       orcidEl.setAttribute('authenticated', String(this.isAuthenticated));
-      orcidEl.appendChild(xmlDoc.createTextNode(`https://orcid.org/${this.orcid}`));
+      orcidEl.appendChild(xmlDoc.createTextNode(this.orcid));
       contrib.appendChild(orcidEl);
     }
   

--- a/src/model/related-article.ts
+++ b/src/model/related-article.ts
@@ -1,6 +1,7 @@
 import { BackmatterEntity } from './backmatter-entity';
 import {JSONObject} from "./types";
 import {Manuscript} from "../model/manuscript";
+import { DOMImplementation } from "xmldom";
 
 export class RelatedArticle extends BackmatterEntity {
   public articleType: string = '';
@@ -17,6 +18,16 @@ export class RelatedArticle extends BackmatterEntity {
     newArticle.articleType = this.articleType;
     newArticle.href = this.href;
     return newArticle;
+  }
+
+  public toXml(): Element {
+    const xmlDoc = new DOMImplementation().createDocument(null, null); 
+    const articleXml = xmlDoc.createElement('related-article');
+    articleXml.setAttribute('ext-link-type', 'doi');
+    articleXml.setAttribute('id', this.id);
+    articleXml.setAttribute('related-article-type', this.articleType);
+    articleXml.setAttribute('xlink:href', this.href);
+    return articleXml;
   }
 
   protected fromXML(xmlNode: Element): void {
@@ -47,12 +58,7 @@ export function serializeRelatedArticles(xmlDoc: Document, manuscript: Manuscrip
 
   const articleMeta = xmlDoc.querySelector('article-meta');
   manuscript.relatedArticles.forEach((article: RelatedArticle) => {
-    const articleXml = xmlDoc.createElement('related-article');
-    articleXml.setAttribute('ext-link-type', 'doi');
-    articleXml.setAttribute('id', article.id);
-    articleXml.setAttribute('related-article-type', article.articleType);
-    articleXml.setAttribute('xlink:href', article.href);
-
-    articleMeta!.appendChild(articleXml)
+    console.log(article.toXml())
+    articleMeta!.appendChild(article.toXml())
   })
 }

--- a/src/model/related-article.ts
+++ b/src/model/related-article.ts
@@ -58,7 +58,6 @@ export function serializeRelatedArticles(xmlDoc: Document, manuscript: Manuscrip
 
   const articleMeta = xmlDoc.querySelector('article-meta');
   manuscript.relatedArticles.forEach((article: RelatedArticle) => {
-    console.log(article.toXml())
     articleMeta!.appendChild(article.toXml())
   })
 }

--- a/test/unit/model/__snapshots__/person.test.ts.snap
+++ b/test/unit/model/__snapshots__/person.test.ts.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`Person class Serialization to XML serializes a Person object to XML 1`] = `"<article><article-meta><contrib-group><contrib contrib-type=\\"author\\" id=\\"author-3888\\" corresp=\\"yes\\"><name><given-names>Siu Sylvia</given-names><surname>Lee</surname></name><contrib-id contrib-id-type=\\"orcid\\" authenticated=\\"true\\">https://orcid.org/0000-0001-5225-4203</contrib-id><email>sylvia.lee@cornell.edu</email><bio><p><bold>Siu Sylvia Lee</bold> is in the Department of Molecular Biology and Genetics, Cornell University, Ithaca, United States</p></bio></contrib></contrib-group></article-meta></article>"`;

--- a/test/unit/model/affiliation.test.ts
+++ b/test/unit/model/affiliation.test.ts
@@ -106,7 +106,7 @@ describe('Affiliation', () => {
         '<aff id="unique_id">' +
           '<label></label>' +
           '<institution></institution>' +
-          '<addr-line><named-content content-type="city"></named-content></addr-line>' +
+          '<city></city>' +
           '<country></country>' +
         '</aff>');
     });
@@ -117,7 +117,7 @@ describe('Affiliation', () => {
         '<aff id="unique_id">' +
           '<label>label</label>' +
           '<institution>Tech Department, eLife Sciences</institution>' +
-          '<addr-line><named-content content-type="city">Cambridge</named-content></addr-line>' +
+          '<city>Cambridge</city>' +
           '<country>United Kingdom</country>' +
         '</aff>');
     });
@@ -202,13 +202,13 @@ describe('serializeAffiliations', () => {
           '<aff id="unique_id">' +
             '<label>label</label>' +
             '<institution>Tech Department, eLife Sciences</institution>' +
-            '<addr-line><named-content content-type="city">Cambridge</named-content></addr-line>' +
+            '<city>Cambridge</city>' +
             '<country>United Kingdom</country>' +
           '</aff>' +
           '<aff id="aff2">' +
             '<label>2</label>' +
             '<institution>Department, University</institution>' +
-            '<addr-line><named-content content-type="city">City</named-content></addr-line>' +
+            '<city>City</city>' +
             '<country>Country</country>' +
           '</aff>' +
         '</contrib-group>' +

--- a/test/unit/model/person.test.ts
+++ b/test/unit/model/person.test.ts
@@ -69,7 +69,7 @@ const mockJsonData = {
 const mockXmlData = `
   <contrib corresp="yes">
     <name><surname>Atherden</surname><given-names>Fred</given-names><suffix>Capt.</suffix></name>
-    <contrib-id authenticated="true" contrib-id-type="orcid">https://orcid.org/0000-0002-6048-1470</contrib-id>
+    <contrib-id authenticated="true" contrib-id-type="orcid">0000-0002-6048-1470</contrib-id>
     <email>fatherden@elifesciences.org</email>
     <bio><p><bold>Jeanine Smith III</bold> is in the Department, University, City, Country</p></bio>
     <xref ref-type="aff" rid="aff2">2</xref>
@@ -274,7 +274,7 @@ describe('Person class', () => {
         expect(xmlSerializer.serializeToString(person.toXml())).toBe(
           '<contrib contrib-type="author" id="author-3888" corresp="yes">' +
             '<name><given-names>Joseph</given-names><surname>Bloggs</surname></name>' +
-            '<contrib-id contrib-id-type="orcid" authenticated="true">https://orcid.org/0000-0001-5225-4203</contrib-id>' + 
+            '<contrib-id contrib-id-type="orcid" authenticated="true">0000-0001-5225-4203</contrib-id>' + 
             '<email>example@example.com</email>' +
             '<bio><p><bold>Joseph Bloggs</bold> is in the Department of Molecular Biology and Genetics, Cornell University, Ithaca, United States</p></bio>' +
           '</contrib>');
@@ -285,7 +285,7 @@ describe('Person class', () => {
         expect(xmlSerializer.serializeToString(person.toXml(affiliations))).toBe(
           '<contrib contrib-type="author" id="author-3888" corresp="yes">' +
             '<name><given-names>Joseph</given-names><surname>Bloggs</surname></name>' +
-            '<contrib-id contrib-id-type="orcid" authenticated="true">https://orcid.org/0000-0001-5225-4203</contrib-id>' + 
+            '<contrib-id contrib-id-type="orcid" authenticated="true">0000-0001-5225-4203</contrib-id>' + 
             '<email>example@example.com</email>' +
             '<bio><p><bold>Joseph Bloggs</bold> is in the Department of Molecular Biology and Genetics, Cornell University, Ithaca, United States</p></bio>' +
             '<xref ref-type=\"aff\" rid=\"aff2\">Some Affiliation Label</xref>' +
@@ -409,7 +409,7 @@ describe('Person class', () => {
         '<article><article-meta><contrib-group>' +
           '<contrib contrib-type="author" id="author-3888" corresp="yes">' +
             '<name><given-names>Joseph</given-names><surname>Bloggs</surname></name>' +
-            '<contrib-id contrib-id-type="orcid" authenticated="true">https://orcid.org/0000-0001-5225-4203</contrib-id>' +
+            '<contrib-id contrib-id-type="orcid" authenticated="true">0000-0001-5225-4203</contrib-id>' +
             '<email>example@example.com</email>' +
             '<bio><p><bold>Joseph Bloggs</bold> is in the Department of Molecular Biology and Genetics, Cornell University, Ithaca, United States</p></bio>' +
           '</contrib>' +


### PR DESCRIPTION
Refactored all existing non-prosemirror classes to expose a `toXml` function. This seems like a good pattern to have for non-prosemirror classes. It has allowed us to write more targeted unit tests for the XML serialisation and should make the classes easier to re-use. 