### PR TITLE
fix: update default config for localstack

### DIFF
--- a/src/config/default.ts
+++ b/src/config/default.ts
@@ -4,8 +4,8 @@ import { Config } from "../types/config";
 export const defaultConfig: Config = {
   port: 8080,
   awsRegion: "eu-west-1",
-  awsAccessKey: "key",
-  awsSecretAccessKey: "secret",
+  awsAccessKey: "test",
+  awsSecretAccessKey: "test",
   awsBucketInputEventQueueUrl: "http://localhost:4566/000000000000/KryiaUploadQueue",
   awsEndpoint: "http://localhost:4566",
   dbEndpoint: "mongo:27017",

--- a/src/config/default.ts
+++ b/src/config/default.ts
@@ -3,7 +3,7 @@ import { Config } from "../types/config";
 // An initial default config
 export const defaultConfig: Config = {
   port: 8080,
-  awsRegion: "eu-west-1",
+  awsRegion: "us-east-1",
   awsAccessKey: "test",
   awsSecretAccessKey: "test",
   awsBucketInputEventQueueUrl: "http://localhost:4566/000000000000/KryiaUploadQueue",


### PR DESCRIPTION
Addresses 2 minor issues...

1. Localstack's default aws region is `us-east-1`, hence update our default config to match.
2. Localstack uses hardcoded values for the secret ID and Key as `test`, so when validating signed requests there is a signature mismatch error that can occur. As such i've updated the default values for our keys to `test` to match.